### PR TITLE
Add a quickstart example for Maven JavaFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# JxBrowser-QuickStart-Maven-JavaFX
+# JxBrowser in JavaFX Maven Project
+
+This example demonstrates how to configure a Maven project with JxBrowser to embed a JavaFX `BrowserView` widget into
+a JavaFX desktop application to display web pages.
+
+## Prerequisites
+
+To compile and run this example please make sure you use Java 17 or higher.
+
+## Download the Project
+
+Clone this repository using the following command:
+
+ ```bash
+ git clone https://github.com/TeamDev-IP/JxBrowser-QuickStart-Maven-JavaFX.git
+ cd JxBrowser-QuickStart-Maven-JavaFX
+ ```
+
+## Get License
+
+Download a free 30-day trial key by sending a request via
+the [web form](https://www.teamdev.com/jxbrowser#evaluate).
+
+## Run the JavaFX Application
+
+Use the following command:
+
+```bash
+mvn clean compile exec:java -Djxbrowser.license.key=<your_license_key>
+```
+
+It will build and start a JavaFX desktop application with JavaFX `BrowserView` inside that
+displays https://html5test.teamdev.com as shown below:
+
+![JavaFX BrowserView](https://jxbrowser-support.teamdev.com/img/articles/javafx-view.png)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.teamdev.jxbrowser.quickstart.maven</groupId>
+    <artifactId>javafx</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <jxbrowser.version>8.1.0</jxbrowser.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <exec.mainClass>HelloFX</exec.mainClass>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>com.teamdev</id>
+            <url>https://europe-maven.pkg.dev/jxbrowser/releases</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.teamdev.jxbrowser</groupId>
+            <artifactId>jxbrowser-cross-platform</artifactId>
+            <version>${jxbrowser.version}</version>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
+            <groupId>com.teamdev.jxbrowser</groupId>
+            <artifactId>jxbrowser-javafx</artifactId>
+            <version>${jxbrowser.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>17</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/main/java/HelloFX.java
+++ b/src/main/java/HelloFX.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
+
+import com.teamdev.jxbrowser.browser.Browser;
+import com.teamdev.jxbrowser.engine.Engine;
+import com.teamdev.jxbrowser.view.javafx.BrowserView;
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+/**
+ * This example demonstrates how to initialize Chromium, create a browser instance
+ * (equivalent of the Chromium tab), embed a JavaFX BrowserView component into JavaFX
+ * scene to display content of the loaded web page, load the required web page.
+ */
+public final class HelloFX extends Application {
+
+    public static void main(String[] args) {
+        launch(args); // Start the JavaFX application.
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        // Initialize Chromium.
+        Engine engine = Engine.newInstance(HARDWARE_ACCELERATED);
+
+        Browser browser = engine.newBrowser();
+
+        // Load the required web page.
+        browser.navigation().loadUrl("https://html5test.teamdev.com");
+
+        // Create and embed JavaFX BrowserView component to display web content.
+        BrowserView view = BrowserView.newInstance(browser);
+
+        Scene scene = new Scene(new BorderPane(view), 1280, 800);
+        primaryStage.setTitle("JxBrowser JavaFX");
+        primaryStage.setScene(scene);
+        primaryStage.show();
+
+        // Shutdown Chromium and release allocated resources.
+        primaryStage.setOnCloseRequest(event -> engine.close());
+    }
+}


### PR DESCRIPTION
This changeset adds a quickstart example for Maven JavaFX.

Issue: TeamDev-IP/JxBrowser/issues/4066